### PR TITLE
fix(ios): add requiresMainQueueSetup

### DIFF
--- a/ios/ScreenshotAware.mm
+++ b/ios/ScreenshotAware.mm
@@ -40,6 +40,11 @@ RCT_EXPORT_MODULE()
     hasListeners = NO;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:


### PR DESCRIPTION
fixes: https://github.com/huextrat/react-native-screenshot-aware/issues/11

Prevent a warning `"Module ScreenshotAware requires main queue setup since it overrides 'init' but doesn't implement 'requiresMainQueueSetup'".`