### PR TITLE
Update codegenConfig to remove outputDir for Android build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,14 +145,9 @@
     "name": "ScreenshotAwareSpec",
     "type": "modules",
     "jsSrcsDir": "./src/codegenSpec",
-    "outputDir": {
-      "ios": "ios/generated",
-      "android": "android/generated"
-    },
     "android": {
       "javaPackageName": "com.screenshotaware"
-    },
-    "includesGeneratedCode": true
+    }
   },
   "create-react-native-library": {
     "type": "turbo-module",


### PR DESCRIPTION
Update codegenConfig to remove outputDir for Android build compatibility

Removed the `outputDir` and `includesGeneratedCode` fields from `codegenConfig` in `package.json` to align with React Native's default Codegen output path (`android/build/generated/source/codegen/jni/`). This fixes the CMake error where the expected JNI directory was missing, ensuring compatibility with the New Architecture in React Native 0.76+

Resolved issue https://github.com/huextrat/react-native-screenshot-aware/issues/198